### PR TITLE
Gulp

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Debug",
             "type": "node",
             "request": "attach",
-            "port": 5858,
+            "port": 9229,
             "timeout": 30000,
             "address": "localhost",
             "restart": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "80:80"
       - "8080:8080"
       - "5858:5858"
+      - "9229:9229"
     volumes:
       - .:/srv
       - ~/.ssh/id_rsa:/home/node/.ssh/id_rsa:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,3 @@ services:
     volumes:
       - .:/srv
       - ~/.ssh/id_rsa:/home/node/.ssh/id_rsa:ro
-      - ~/.gitconfig:/home/node/.gitconfig:ro
-      - ~/.npmrc:/home/node/.npmrc:ro

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,7 @@
 // TODO: 
-// - call forever programmatically
 // - include the tests and code coverage generation
-// - isolate the 'generic' gulp tasks in a dedicated component (as before)
 
-// General dependencies
-var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
-var exec = require('child_process').exec;
-var _ = require('lodash');
+var gulpTasks = require('./src/serafin/gulp-tasks/index.js');
 
 // Gulp dependencies
 var gulp = require('gulp');
@@ -17,143 +10,16 @@ var jsonSchemaToTypescript = require('@serafin/gulp-serafin-json-schema-to-types
 var del = require('del');
 var merge = require('merge-stream');
 
-// Tasks variables
-var sourceDirectory = __dirname + '/src';
-var outputDirectory = __dirname + '/lib';
-var outputTypingsDirectory = __dirname + '/lib/typings'
-var buildFile = outputDirectory + '/build.txt'
-
-var assetsFormat = '*.+(xml|js|json|htm|html|css|ico|jpg|jpeg|png|gif|tiff|svg|webp|ttf|eot|otf|woff)';
-
 // General tasks
-gulp.task('default', ['run']);
-gulp.task('dev', ['watch', 'watch-build-done', 'run-dev']);
-gulp.task('watch', ['watch-typescript', 'watch-assets']);
+gulp.task('default', ['start']);
+gulp.task('dev', ['watch', 'watch-build-done', 'start']);
+gulp.task('watch', ['watch-typescript', 'watch-model-example', 'watch-assets']);
 gulp.task('build', ['build-typescript', 'copy-assets']);
-gulp.task('run', function () { run('--minUptime 1000 --spinSleepTime 1000'); });
-gulp.task('run-dev', function () { run('-c "node --debug" --minUptime 1000 --spinSleepTime 1000 -m 1'); });
 
-/**
- * Run the main task with forever
- * 
- * @param options forever options
- */
-function run(options) {
-    var process = exec(`forever ${options} lib/example/index.js`);
-    process.stdout.on('data', function (data) {
-        console.log(data);
-    });
-    process.stderr.on('data', function (data) {
-        console.error(data);
-    });
-}
-
-/**
- * Write the build file with the current date in it
- */
-function buildDone() {
-    try {
-        fs.writeFileSync(buildFile, new Date());
-    } catch (e) {
-        console.error('Build file not created');
-    }
-}
-
-/**
- * Restart the forever service
- */
-function restart() {
-    return exec('forever restartall', function (err, stdout, stderr) {
-        console.log(stdout);
-        console.log(stderr);
-    });
-}
-
-/**
- * Delete all files in the output directory
- * /!\ Use with caution
- */
-gulp.task('clean', function (callback) {
-    del([
-        outputDirectory + '/*'
-    ], callback);
-});
-
-gulp.task('watch-build-done', function () {
-    return plugins.watch(buildFile, { usePolling: true, awaitWriteFinish: true, alwaysStat: true }, function () {
-        restart();
-    });
-});
-
-/**
- * Watch any assets that need to be copied over to the output directory.
- */
-gulp.task('watch-assets', function () {
-    // Polling is used to work properly with containers
-    return plugins.watch([sourceDirectory + '/**///' + assetsFormat, "!" + sourceDirectory + "/tsconfig.json"], { usePolling: true, awaitWriteFinish: true, alwaysStat: true },
-        function () {
-            return gulp.start('copy-assets');
-        });
-});
-
-/**
- * Watch typescript sources and trigger compilation.
- */
-gulp.task('watch-typescript', function () {
-    return plugins.watch([sourceDirectory + '/**/*.ts'], { usePolling: true, awaitWriteFinish: true, alwaysStat: true },
-        function () {
-            return gulp.start('build-typescript');
-        });
-
-
-});
-
-/**
- * Copy all assets to the output directory.
- * This task keeps the directory structure.
- */
-gulp.task('copy-assets', function () {
-    return gulp.src([sourceDirectory + '/**/' + assetsFormat, "!" + sourceDirectory + "/tsconfig.json"])
-        .pipe(gulp.dest(outputDirectory))
-        .on('end', () => buildDone());
-});
-
-/**
- * Shared reference to the typescript project configuration.
- * It improves performances.
- */
-var tsProject;
-
-/**
- * Build typescript sources & generate typings.
- */
-gulp.task('build-typescript', function () {
-    // Create the typescript project if it is not initialized yet
-    tsProject = tsProject || plugins.typescript.createProject(sourceDirectory + '/tsconfig.json', { outDir: sourceDirectory });
-    // Create a stream to compile all typescript sources
-    var tsStream = gulp.src([sourceDirectory + '/**/*.ts', sourceDirectory + '/**/*.tsx'])
-        .pipe(plugins.sourcemaps.init())
-        .pipe(tsProject());
-    // Write js files and remap sourcemap path
-    var jsStream = tsStream.js
-        .pipe(plugins.sourcemaps.write(".", {
-            includeContent: false,
-            sourceRoot: path.relative(outputDirectory, sourceDirectory).replace(/\\/g, "/")
-        }))
-        .pipe(gulp.dest(outputDirectory));
-    // Write typings files
-    var dtsStream = tsStream.dts.pipe(gulp.dest(outputTypingsDirectory));
-    // Combine streams so we can wait completion of both
-    jsStream = merge(jsStream, dtsStream);
-    jsStream.on('end', () => buildDone());
-    return jsStream;
-});
-
-/**
- * Build json schemas. For testing.
- */
-gulp.task('build-json-schema', function () {
-    return gulp.src(sourceDirectory + '/model/**/*.json')
-        .pipe(jsonSchemaToTypescript("model.ts"))
-        .pipe(gulp.dest(sourceDirectory + '/model/'))
-});
+gulpTasks.assets(gulp,
+    [__dirname + '/src/**/*.+(xml|js|json|htm|html|css|ico|jpg|jpeg|png|gif|tiff|svg|webp|ttf|eot|otf|woff)', '!' + __dirname + '/src/tsconfig.json'],
+    __dirname + '/lib');
+gulpTasks.typescript(gulp, __dirname + '/src', __dirname + '/src/tsconfig.json', __dirname + '/lib', __dirname + '/lib/typings');
+gulpTasks.model(gulp, __dirname + '/src/example/**/*.model.json', __dirname + '/src/example/model', 'example');
+gulpTasks.utils(gulp, __dirname + '/lib');
+gulpTasks.runner(gulp, 'lib/example/index.js', __dirname + '/lib/build.txt', __dirname + '/lib/pid', true);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,26 +1,18 @@
-// TODO: 
-// - include the tests and code coverage generation
-
-var gulpTasks = require('./src/serafin/gulp-tasks/index.js');
-
-// Gulp dependencies
 var gulp = require('gulp');
-var plugins = require('gulp-load-plugins')();
-var jsonSchemaToTypescript = require('@serafin/gulp-serafin-json-schema-to-typescript');
-var del = require('del');
-var merge = require('merge-stream');
+var gulpTasks = require('./src/serafin/gulp-tasks/index.js');
+var gulpTasksModel = require('@serafin/gulp-serafin-json-schema-to-typescript').gulpTasksModel;
 
-// General tasks
 gulp.task('default', ['start']);
 gulp.task('dev', ['watch', 'watch-build-done', 'start']);
 gulp.task('watch', ['watch-typescript', 'watch-model-example', 'watch-assets']);
 gulp.task('build', ['build-typescript', 'copy-assets']);
+gulp.task('build-done', ['restart', 'test']);
 
 gulpTasks.assets(gulp,
     [__dirname + '/src/**/*.+(xml|js|json|htm|html|css|ico|jpg|jpeg|png|gif|tiff|svg|webp|ttf|eot|otf|woff)', '!' + __dirname + '/src/tsconfig.json'],
     __dirname + '/lib');
 gulpTasks.typescript(gulp, __dirname + '/src', __dirname + '/src/tsconfig.json', __dirname + '/lib', __dirname + '/lib/typings');
-gulpTasks.model(gulp, __dirname + '/src/example/**/*.model.json', __dirname + '/src/example/model', 'example');
 gulpTasks.utils(gulp, __dirname + '/lib');
 gulpTasks.runner(gulp, __dirname + '/lib/example/index.js', __dirname + '/lib/build.txt', __dirname + '/lib/pid', true);
 gulpTasks.test(gulp, __dirname + '/lib/**/test/*.js', __dirname + '/lib/coverage');
+gulpTasksModel(gulp, __dirname + '/src/example/**/*.model.json', __dirname + '/src/example/model', 'example');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,4 +22,5 @@ gulpTasks.assets(gulp,
 gulpTasks.typescript(gulp, __dirname + '/src', __dirname + '/src/tsconfig.json', __dirname + '/lib', __dirname + '/lib/typings');
 gulpTasks.model(gulp, __dirname + '/src/example/**/*.model.json', __dirname + '/src/example/model', 'example');
 gulpTasks.utils(gulp, __dirname + '/lib');
-gulpTasks.runner(gulp, 'lib/example/index.js', __dirname + '/lib/build.txt', __dirname + '/lib/pid', true);
+gulpTasks.runner(gulp, __dirname + '/lib/example/index.js', __dirname + '/lib/build.txt', __dirname + '/lib/pid', true);
+gulpTasks.test(gulp, __dirname + '/lib/**/test/*.js', __dirname + '/lib/coverage');

--- a/src/serafin/gulp-tasks/index.js
+++ b/src/serafin/gulp-tasks/index.js
@@ -151,15 +151,9 @@ module.exports = {
             }
             options.push(command);
 
-            process = spawn('node', options, { detached: true });
+            process = spawn('node', options, { stdio: 'inherit' });
             fs.writeFileSync(pidFile, process.pid);
 
-            process.stdout.on('data', function (data) {
-                console.log(data.toString());
-            });
-            process.stderr.on('data', function (data) {
-                console.error(data.toString());
-            });
             process.on('exit', function (data) {
                 console.log('*** Process exited ***');
                 process = null;
@@ -195,21 +189,10 @@ module.exports = {
 
     test(gulp, jsTestsPath, coverageReportsDirectory) {
         gulp.task('test', function () {
-            function writeProcessOutput(process) {
-                process['stdout'].on('data', function (data) {
-                    console.log(data.toString());
-                });
-                process['stderr'].on('data', function (data) {
-                    console.error(data.toString());
-                });
-
-                return process;
-            }
-
-            istanbul = writeProcessOutput(spawn('istanbul', ['cover', '--dir', coverageReportsDirectory, '_mocha', '--', '-R', 'spec', jsTestsPath]));
+            istanbul = spawn('istanbul', ['cover', '--dir', coverageReportsDirectory, '_mocha', '--', '-R', 'spec', jsTestsPath], { stdio: 'inherit' });
             istanbul.on('close', function (data) {
-                writeProcessOutput(spawn('remap-istanbul', ['-i', coverageReportsDirectory + '/coverage.json', '-t', 'lcovonly', '-o', coverageReportsDirectory + '/lcov.info']));
-                writeProcessOutput(spawn('remap-istanbul', ['-i', coverageReportsDirectory + '/coverage.json', '-t', 'html', '-o', coverageReportsDirectory + '/lcov-report']));
+                spawn('remap-istanbul', ['-i', coverageReportsDirectory + '/coverage.json', '-t', 'lcovonly', '-o', coverageReportsDirectory + '/lcov.info'], { stdio: 'inherit' });
+                spawn('remap-istanbul', ['-i', coverageReportsDirectory + '/coverage.json', '-t', 'html', '-o', coverageReportsDirectory + '/lcov-report'], { stdio: 'inherit' });
             });
         });
     }

--- a/src/serafin/gulp-tasks/index.js
+++ b/src/serafin/gulp-tasks/index.js
@@ -1,0 +1,210 @@
+var path = require('path');
+var spawn = require('child_process').spawn;
+var fs = require('fs');
+
+// Gulp dependencies
+var gulp = require('gulp');
+var plugins = require('gulp-load-plugins')();
+var jsonSchemaToTypescript = require('@serafin/gulp-serafin-json-schema-to-typescript');
+var del = require('del');
+var merge = require('merge-stream');
+
+module.exports = {
+    /**
+     * @param gulp Gulp object
+     * @param sourcePath Path(s) of the files containing JSON-Schema models 
+     * @param modelDirectory Model file directory
+     * @param taskSuffix Optional task suffix allow to create multiple tasks for differents model files, in case of sub-projects
+     */
+    model: function (gulp, sourcePath, modelDirectory, taskSuffix = null) {
+        if (typeof taskSuffix == 'string') {
+            taskSuffix = '-' + taskSuffix;
+        } else {
+            taskSuffix = '';
+        }
+
+        gulp.task('watch-model' + taskSuffix, function () {
+            return gulp.watch(adaptPath(sourcePath), { usePolling: true, awaitWriteFinish: true, alwaysStat: true },
+                function () {
+                    return gulp.start('build-model' + taskSuffix);
+                });
+        });
+
+        gulp.task('build-model' + taskSuffix, function () {
+            return gulp.src(adaptPath(sourcePath))
+                .pipe(jsonSchemaToTypescript(modelDirectory + "model.ts"))
+                .pipe(gulp.dest(modelPath))
+        });
+    },
+
+    /**
+     * @param gulp Gulp object
+     * @param sourceDirectory Directory containing typescript sources
+     * @param tsConfigFile Typescript configuration file
+     * @param outputDirectory Directory where the project is built
+     * @param outputTypingsDirectory Directory where the typings are built
+     */
+    typescript: function (gulp, sourceDirectory, tsConfigFile, outputDirectory, outputTypingsDirectory) {
+        // Shared reference to the typescript project configuration.
+        // It improves performances.
+        var tsProject;
+
+        // Watch typescript sources and trigger compilation.
+        gulp.task('watch-typescript', function () {
+            return gulp.watch(sourceDirectory + '/**/*.ts', { usePolling: true, awaitWriteFinish: true, alwaysStat: true },
+                function () {
+                    return gulp.start('build-typescript');
+                });
+        });
+
+        gulp.task('build-typescript', function () {
+            // Create the typescript project if it is not initialized yet
+            tsProject = tsProject || plugins.typescript.createProject(tsConfigFile, { outDir: sourceDirectory });
+            // Create a stream to compile all typescript sources
+            var tsStream = gulp.src(sourceDirectory + '/**/*.ts')
+                .pipe(plugins.sourcemaps.init())
+                .pipe(tsProject());
+            // Write js files and remap sourcemap path
+            var jsStream = tsStream.js
+                .pipe(plugins.sourcemaps.write(".", {
+                    includeContent: false,
+                    sourceRoot: path.relative(outputDirectory, sourceDirectory).replace(/\\/g, "/")
+                }))
+                .pipe(gulp.dest(outputDirectory));
+            // Write typings files
+            var dtsStream = tsStream.dts.pipe(gulp.dest(outputTypingsDirectory));
+            // Combine streams so we can wait completion of both
+            jsStream = merge(jsStream, dtsStream);
+            jsStream.on('end', () => buildDone());
+            return jsStream;
+        });
+    },
+
+    /**
+     * @param gulp Gulp object
+     * @param assetsPath Path(s) of the assets to be copied
+     * @param outputDirectory Directory where the assets are copied
+     */
+    assets(gulp, assetsPath, outputDirectory) {
+        // Watch any assets that need to be copied over to the output directory.
+        gulp.task('watch-assets', function () {
+            // Polling is used to work properly with mounted file systems (VM shares, container volumes...)
+            return plugins.watch(adaptPath(assetsPath), { usePolling: true, awaitWriteFinish: true, alwaysStat: true },
+                function () {
+                    return gulp.start('copy-assets');
+                });
+        });
+
+        // Copy all assets to the output directory.
+        // This task keeps the directory structure.
+        gulp.task('copy-assets', function () {
+            return gulp.src(assetsPath)
+                .pipe(gulp.dest(outputDirectory))
+                .on('end', () => buildDone());
+        });
+    },
+
+    /**
+     * @param gulp Gulp object
+     * @param outputDirectory Build directory
+     */
+    utils(gulp, outputDirectory) {
+        /**
+         * Delete all files in the output directory
+         */
+        gulp.task('clean', function (callback) {
+            del([
+                outputDirectory + '/*'
+            ], callback);
+        });
+    },
+
+    /**
+     * @param gulp Gulp object
+     * @param command Command to run the application
+     * @param buildFile Path of the build file
+     */
+    runner(gulp, command, buildFile, pidFile, debug) {
+        var process = null;
+        gulp.task('build-done', function () {
+            try {
+                fs.writeFileSync(buildFile, new Date());
+            } catch (e) {
+                console.error('Build file not created: ' + e);
+            }
+        });
+
+        gulp.task('watch-build-done', function () {
+            return plugins.watch(buildFile, { usePolling: true, awaitWriteFinish: true, alwaysStat: true },
+                function () {
+                    return gulp.start('restart');
+                });
+        });
+
+        gulp.task('start', function () {
+            options = [];
+            if (!!debug) {
+                options.push('--inspect');
+            }
+            options.push(command);
+
+            process = spawn('node', options, { detached: true });
+            fs.writeFileSync(pidFile, process.pid);
+
+            process.stdout.on('data', function (data) {
+                console.log(data.toString());
+            });
+            process.stderr.on('data', function (data) {
+                console.error(data.toString());
+            });
+            process.on('exit', function (data) {
+                console.log('*** Process exited ***');
+                process = null;
+            });
+        });
+
+        gulp.task('restart', function () {
+            if (!process) {
+                fs.access(pidFile, fs.constants.R_OK | fs.constants.W_OK, (err) => {
+                    if (err) {
+                        console.error('No application running or PID error');
+                    } else {
+                        var pid = fs.readFileSync(pidFile);
+                        process = spawn('kill', [pid]);
+                        process.stdout.on('close', function (data) {
+                            return gulp.start('start');
+                        });
+                    }
+                });
+            } else if (process) {
+                if (process.exitCode != null) {
+                    gulp.start('start');
+                } else {
+                    process.kill();
+                    process.on('close', function () {
+                        process = null;
+                        return gulp.start('start');
+                    });
+                }
+            }
+        });
+    }
+};
+
+function buildDone() {
+    if (gulp.hasTask('build-done')) {
+        gulp.start('build-done');
+    }
+}
+
+function adaptPath(path) {
+    if (typeof path == 'String') {
+        path = [path];
+    }
+
+    if (!typeof path == 'Array') {
+        throw Error("Source directory: Array or String expected");
+    }
+
+    return path;
+}

--- a/src/serafin/gulp-tasks/index.js
+++ b/src/serafin/gulp-tasks/index.js
@@ -11,6 +11,8 @@ var merge = require('merge-stream');
 
 module.exports = {
     /**
+     * Provides the Gulp tasks watch-model and build-model
+     * 
      * @param gulp Gulp object
      * @param sourcePath Path(s) of the files containing JSON-Schema models 
      * @param modelDirectory Model file directory
@@ -38,6 +40,8 @@ module.exports = {
     },
 
     /**
+     * Provides the Gulp tasks watch-typescript and build-typescript
+     * 
      * @param gulp Gulp object
      * @param sourceDirectory Directory containing typescript sources
      * @param tsConfigFile Typescript configuration file
@@ -81,6 +85,8 @@ module.exports = {
     },
 
     /**
+     * Provides the Gulp tasks watch-assets and build-assets
+     * 
      * @param gulp Gulp object
      * @param assetsPath Path(s) of the assets to be copied
      * @param outputDirectory Directory where the assets are copied
@@ -105,6 +111,9 @@ module.exports = {
     },
 
     /**
+     * Provides the gulp task:
+     * - clean: remove the content of the output directory
+     * 
      * @param gulp Gulp object
      * @param outputDirectory Build directory
      */
@@ -120,6 +129,12 @@ module.exports = {
     },
 
     /**
+     * Provides the Gulp tasks:
+     * - build-done: create a new build text file after a build)
+     * - watch-build-done: monitor the build text file, and restart the app and launches the test suite (if enabled) on a file change
+     * - start: run the app
+     * - restart: restart the app
+     * 
      * @param gulp Gulp object
      * @param command Command to run the application
      * @param buildFile Path of the build file
@@ -187,6 +202,15 @@ module.exports = {
         });
     },
 
+    /**
+     * Provides the Gulp task:
+     * - test: run the unit tests, display their output, builds a Typescript LCOV file (for code coverage over the Typescript sources),
+     * builds a lcov-report webpage in the coverage directory
+     * 
+     * @param gulp Gulp object
+     * @param jsTestsPath Path of the JS test files
+     * @param coverageReportsDirectory Destination directory of the coverage reports 
+     */
     test(gulp, jsTestsPath, coverageReportsDirectory) {
         gulp.task('test', function () {
             istanbul = spawn('istanbul', ['cover', '--dir', coverageReportsDirectory, '_mocha', '--', '-R', 'spec', jsTestsPath], { stdio: 'inherit' });


### PR DESCRIPTION
Gulp revamped
Generic gulp tasks have been moved as modular tasks in the gulp-tasks directory (future module)
We're now using the chrome inspector as the new debugger on port 9229
Unit tests run on builds, with HTML coverage reports and LCOV reports (for VSCode integration) for Typescript
Forever was removed, replaced by process.spawn and kill commands